### PR TITLE
make end of label detection platform dependent

### DIFF
--- a/zebralabel/nbactions.xml
+++ b/zebralabel/nbactions.xml
@@ -36,4 +36,11 @@
                 <exec.executable>${profiler.java}</exec.executable>
             </properties>
         </action>
+        <action>
+            <actionName>CUSTOM-deploy to Run</actionName>
+            <displayName>deploy to Run</displayName>
+            <goals>
+                <goal>deploy:deploy</goal>
+            </goals>
+        </action>
     </actions>

--- a/zebralabel/src/main/java/com/oldworldind/app/gui/zebralabel/IoUtils.java
+++ b/zebralabel/src/main/java/com/oldworldind/app/gui/zebralabel/IoUtils.java
@@ -123,9 +123,12 @@ public final class IoUtils {
         return false;
     }
 
-    static boolean pingServer(final String serverAndProtocol, int port) {
+    static boolean pingServer(final String serverAndProtocol, int port, int myTime) {
         Socket sock = null;
         int timeToTryReach = 10;
+        if (myTime > 0 && myTime < 61) {
+            timeToTryReach = myTime;
+        }
         try {
             sock = new Socket(serverAndProtocol, port);
 

--- a/zebralabel/src/main/java/com/oldworldind/app/gui/zebralabel/PrinterFinderSvc.java
+++ b/zebralabel/src/main/java/com/oldworldind/app/gui/zebralabel/PrinterFinderSvc.java
@@ -2,8 +2,8 @@ package com.oldworldind.app.gui.zebralabel;
 
 import java.net.MalformedURLException;
 import java.net.URL;
-import java.util.logging.Level;
 import java.util.regex.Pattern;
+
 import javax.print.PrintService;
 import javax.print.PrintServiceLookup;
 import javax.print.attribute.PrintServiceAttribute;
@@ -44,8 +44,18 @@ public class PrinterFinderSvc {
             return false;
         }
 
-        String server = nameToMatch.substring(0, posBeforePort);
-        return IoUtils.pingServer(server, iPort);
+        return true;
+    }
+
+    public boolean isServicePingable(String serviceforsocketandPort, int timeInSeconds) {
+        if (!isNameIpStyle(serviceforsocketandPort)) {
+            return false;
+        }
+
+        int posBeforePort = serviceforsocketandPort.indexOf(':');
+        int iPort = getPort(serviceforsocketandPort);
+        String server = serviceforsocketandPort.substring(0, posBeforePort);
+        return IoUtils.pingServer(server, iPort, timeInSeconds);
     }
 
     public URL getPrinterUrl(String nameProvided) {

--- a/zebralabel/src/main/java/com/oldworldind/app/gui/zebralabel/ZplFileParser.java
+++ b/zebralabel/src/main/java/com/oldworldind/app/gui/zebralabel/ZplFileParser.java
@@ -12,6 +12,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 import org.apache.commons.io.FileUtils;
+import org.apache.commons.lang3.SystemUtils;
 import org.apache.log4j.Logger;
 
 /**
@@ -25,7 +26,13 @@ public final class ZplFileParser {
     private static final String BYTES_WINDOWS_WTF = "Cp1252";
     private static final String START_OF_LABEL_CODE = "?XA";
     private static final String END_OF_LABEL_CODE = "?XZ";
-    private static final String END_OF_LABEL_LINE = "?PQ";
+    private static String END_OF_LABEL_LINE = "?PQ";
+    static {
+        if (SystemUtils.IS_OS_WINDOWS) {
+            END_OF_LABEL_LINE = "¬PQ";
+        }
+        LOG.info("zipfile parsing for:" + END_OF_LABEL_LINE + ": for end of label");
+    }
     public static final String BYTE_CHAR_READER = BYTES_WINDOWS_WTF;
     public static final String LABEL_COUNT_PROPERTY = "label-count";
     public static final String FILE_SIZE_COUNT = "file-size";

--- a/zebralabel/src/test/java/com/oldworldind/app/gui/zebralabel/IoUtilsTest.java
+++ b/zebralabel/src/test/java/com/oldworldind/app/gui/zebralabel/IoUtilsTest.java
@@ -32,7 +32,7 @@ public class IoUtilsTest {
 
 //        boolean result = IoUtils.pingServer(serverAndProtocol, printServicePort);
 
-        Boolean result = IoUtils.pingServer(TESTPRINTSERVER, printServicePort);
+        Boolean result = IoUtils.pingServer(TESTPRINTSERVER, printServicePort, 20);
         assertNotNull("must have a result from ping try on:" + serverAndProtocol, result);
         LOG.warn("port:" + printServicePort + " on ping yields:" + result + " vs:" + TESTPRINTSERVER);
     }


### PR DESCRIPTION
remove timeout check for socket based printing e.g. 172.16.2.31:9100 will not try a ping prior to writing to port 9100
